### PR TITLE
e300_fifo_config.cpp cast timeout to long

### DIFF
--- a/host/lib/usrp/e300/e300_fifo_config.cpp
+++ b/host/lib/usrp/e300/e300_fifo_config.cpp
@@ -108,7 +108,7 @@ struct e300_fifo_poll_waiter
         boost::mutex::scoped_lock l(_mutex);
         if (_poll_claimed)
         {
-            _cond.timed_wait(l, boost::posix_time::microseconds(timeout*1000000));
+            _cond.timed_wait(l, boost::posix_time::microseconds(long(timeout*1000000)));
         }
         else
         {


### PR DESCRIPTION
Prevent compiler errors with newer version of boost. The constructor takes a bool according to documentation, since ever.